### PR TITLE
Revert 11 -- fix doors on corners

### DIFF
--- a/src/resources/level.py
+++ b/src/resources/level.py
@@ -41,7 +41,10 @@ class Level:
                 y = randint(0, self.height - 1)
                 x = 0
 
-            if self.board[y][x] != self.door_symbol:
+            if self.board[y][x] != self.door_symbol and self.board[y][x] not in (Text("╚", style="bold white"),
+                                                                                 Text("╗", style="bold white"),
+                                                                                 Text("╝", style="bold white"),
+                                                                                 Text("╔", style="bold white")):
                 self.board[y][x] = self.door_symbol
                 doors -= 1
 

--- a/src/resources/level.py
+++ b/src/resources/level.py
@@ -41,7 +41,7 @@ class Level:
                 y = randint(0, self.height - 1)
                 x = 0
 
-            if self.board[y][x] != self.door_symbol and self.board[y][x] not in ('╔', '╗', '╚', '╝'):
+            if self.board[y][x] != self.door_symbol:
                 self.board[y][x] = self.door_symbol
                 doors -= 1
 

--- a/src/resources/level.py
+++ b/src/resources/level.py
@@ -41,10 +41,7 @@ class Level:
                 y = randint(0, self.height - 1)
                 x = 0
 
-            if self.board[y][x] != self.door_symbol and self.board[y][x] not in (Text("╚", style="bold white"),
-                                                                                 Text("╗", style="bold white"),
-                                                                                 Text("╝", style="bold white"),
-                                                                                 Text("╔", style="bold white")):
+            if self.board[y][x] != self.door_symbol and self.board[y][x].text not in ("╚", "╗", "╝", "╔"):
                 self.board[y][x] = self.door_symbol
                 doors -= 1
 


### PR DESCRIPTION
Updated it to do ``self.board[y][x].text`` to get the raw text instead of the class. Permanently fixes all spawning on borders.